### PR TITLE
docs: now using explicit nixpkgs in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ Here is a basic example of how to use this pattern:
 {
   description = "A basic flake";
 
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   inputs.systems.url = "github:nix-systems/default";
 
-  outputs = { self, systems, nixpkgs }:
+  outputs = { systems, nixpkgs, ... }:
     let
       eachSystem = nixpkgs.lib.genAttrs (import systems);
     in
@@ -40,7 +41,7 @@ And here you can see all the systems for that flake:
 
 `$ nix flake show ./examples/simple/`
 ```
-git+file:///home/zimbatm/go/src/github.com/nix-systems/nix-systems?dir=examples%2fsimple
+git+file:///home/zimbatm/go/src/github.com/nix-systems/nix-systems?dir=examples/simple
 └───packages
     ├───aarch64-darwin
     │   └───hello: package 'hello-2.12.1'
@@ -63,6 +64,8 @@ flake systems in the local `flake.systems.nix` file.
 {
   description = "A consumer flake";
 
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
   # Here we use a local list of systems
   inputs.systems.url = "path:./flake.systems.nix";
   inputs.systems.flake = false;
@@ -73,7 +76,7 @@ flake systems in the local `flake.systems.nix` file.
   # Here we override the list of systems with only our own
   inputs.demo.inputs.systems.follows = "systems";
 
-  outputs = { self, systems, nixpkgs, demo }:
+  outputs = { systems, nixpkgs, demo, ... }:
     let
       eachSystem = nixpkgs.lib.genAttrs (import systems);
     in
@@ -88,7 +91,7 @@ flake systems in the local `flake.systems.nix` file.
 
 `$ nix flake show ./examples/consumer/`
 ```
-git+file:///home/zimbatm/go/src/github.com/nix-systems/nix-systems?dir=examples%2fconsumer
+git+file:///home/zimbatm/go/src/github.com/nix-systems/nix-systems?dir=examples/consumer
 └───packages
     └───x86_64-linux
         └───hello: package 'hello-2.12.1'
@@ -108,7 +111,7 @@ missing, please create a ticket on this repo.
 Example usage:
 `$ nix flake show ./examples/simple/ --override-input systems github:nix-systems/x86_64-linux`
 ```
-git+file:///home/zimbatm/go/src/github.com/nix-systems/nix-systems?dir=examples%2fsimple
+git+file:///home/zimbatm/go/src/github.com/nix-systems/nix-systems?dir=examples/simple
 └───packages
     └───x86_64-linux
         └───hello: package 'hello-2.12.1'

--- a/examples/consumer/flake.lock
+++ b/examples/consumer/flake.lock
@@ -9,7 +9,7 @@
       },
       "locked": {
         "lastModified": 1,
-        "narHash": "sha256-2k9yCSSZcBYkUM0l4/AY1aiIwwfGgBuLcCb8MhK52tg=",
+        "narHash": "sha256-A7PpxvaMPRqxtVvDRihOQWgGf0tD+1JE4x4A6cOX53k=",
         "path": "../simple",
         "type": "path"
       },
@@ -20,26 +20,34 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-Kr/O/UlfqAtoFmkZeAaphsxogeaN8a/IugBApFzPfpk=",
-        "path": "/nix/store/chj79hz14v92rmdhpgw8pr21gw50pkwk-source",
-        "type": "path"
+        "lastModified": 1738142207,
+        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+        "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-Kr/O/UlfqAtoFmkZeAaphsxogeaN8a/IugBApFzPfpk=",
-        "path": "/nix/store/chj79hz14v92rmdhpgw8pr21gw50pkwk-source",
-        "type": "path"
+        "lastModified": 1738142207,
+        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+        "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/examples/consumer/flake.nix
+++ b/examples/consumer/flake.nix
@@ -1,6 +1,8 @@
 {
   description = "A consumer flake";
 
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
   # Here we use a local list of systems
   inputs.systems.url = "path:./flake.systems.nix";
   inputs.systems.flake = false;
@@ -11,7 +13,7 @@
   # Here we override the list of systems with only our own
   inputs.demo.inputs.systems.follows = "systems";
 
-  outputs = { self, systems, nixpkgs, demo }:
+  outputs = { systems, nixpkgs, demo, ... }:
     let
       eachSystem = nixpkgs.lib.genAttrs (import systems);
     in

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -4,18 +4,22 @@ Invoke with:
 ```console
 $ nix run .#hello
 Hello world!
-$ nix flake show 
-warning: Git tree '/home/zimbatm/go/src/github.com/zimbatm/flake-systems' is dirty
-git+file:///home/zimbatm/go/src/github.com/zimbatm/flake-systems?dir=demo
+$ nix flake show
+warning: Git tree '/home/zimbatm/go/src/github.com/nix-systems/nix-systems' is dirty
+git+file:///home/zimbatm/go/src/github.com/nix-systems/nix-systems?dir=examples/simple
 └───packages
+    ├───aarch64-darwin
+    │   └───hello: package 'hello-2.12.1'
     ├───aarch64-linux
+    │   └───hello: package 'hello-2.12.1'
+    ├───x86_64-darwin
     │   └───hello: package 'hello-2.12.1'
     └───x86_64-linux
         └───hello: package 'hello-2.12.1'
 ```
 
-In order to update the flake.lock, run:
+In order to update the `flake.lock`, run:
 
 ```console
-$ nix flake update --flake-registry "$(dirname "$PWD")/flake-registry.json"
+$ nix flake update
 ```

--- a/examples/simple/flake.lock
+++ b/examples/simple/flake.lock
@@ -2,14 +2,18 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-Kr/O/UlfqAtoFmkZeAaphsxogeaN8a/IugBApFzPfpk=",
-        "path": "/nix/store/chj79hz14v92rmdhpgw8pr21gw50pkwk-source",
-        "type": "path"
+        "lastModified": 1738142207,
+        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+        "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
@@ -20,11 +24,11 @@
     },
     "systems": {
       "locked": {
-        "lastModified": 1680980633,
-        "narHash": "sha256-mz27VfAExPMYuoWsb1cf++DIyUWWBEbAvXD0BJ+AT/E=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
         "repo": "default",
-        "rev": "4e9a51a15ceb27e5141819142a7d2ee827943fc8",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {

--- a/examples/simple/flake.nix
+++ b/examples/simple/flake.nix
@@ -1,9 +1,10 @@
 {
   description = "A basic flake";
 
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   inputs.systems.url = "github:nix-systems/default";
 
-  outputs = { self, systems, nixpkgs }:
+  outputs = { systems, nixpkgs, ... }:
     let
       eachSystem = nixpkgs.lib.genAttrs (import systems);
     in


### PR DESCRIPTION
While I was adding nixpkgs input I noticed a few other docs issues, so I fixed them all as they are all tiny.

Closes #13.
